### PR TITLE
Add configurable benefits path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Credit Card Benefits Tracker
+
+This Streamlit app helps track recurring credit card benefits. It can be run locally or inside Docker.
+
+## Configuring the data file
+
+The application reads and writes benefit information to a JSON file. By default it uses `credit_card_benefits.json` in the working directory. You can override this location by setting the `BENEFITS_DATA_FILE` environment variable.
+
+### Example Docker usage
+
+Build the image:
+
+```bash
+docker build -t cc-benefits .
+```
+
+Run the container while specifying a custom data file:
+
+```bash
+docker run -p 8501:8501 \
+  -e BENEFITS_DATA_FILE=/app/data/benefits.json \
+  cc-benefits
+```
+
+If the variable is not set, the default file path will be used.

--- a/ccb.py
+++ b/ccb.py
@@ -7,14 +7,21 @@ import os
 import matplotlib.pyplot as plt
 from datetime import datetime, timedelta
 
-# File to store the benefits data
-DATA_FILE = "credit_card_benefits.json"
+# Default file to store the benefits data
+# The location can be customized with the BENEFITS_DATA_FILE environment variable.
+DEFAULT_DATA_FILE = "credit_card_benefits.json"
+
+
+def get_data_file():
+    """Return the path to the benefits data file."""
+    return os.getenv("BENEFITS_DATA_FILE", DEFAULT_DATA_FILE)
 
 # Section 2: Load and Save Benefits Data
 def load_benefits():
-    if os.path.exists(DATA_FILE):
+    data_file = get_data_file()
+    if os.path.exists(data_file):
         try:
-            with open(DATA_FILE, "r") as file:
+            with open(data_file, "r") as file:
                 return json.load(file)
         except (json.JSONDecodeError, IOError) as e:
             st.error(f"Error loading benefits file: {e}")
@@ -24,8 +31,9 @@ def load_benefits():
     return {}
 
 def save_benefits():
+    data_file = get_data_file()
     try:
-        with open(DATA_FILE, "w") as file:
+        with open(data_file, "w") as file:
             json.dump(benefits, file, indent=4)
     except IOError as e:
         st.error(f"Error saving benefits file: {e}")


### PR DESCRIPTION
## Summary
- make benefits data path configurable via `BENEFITS_DATA_FILE`
- add helper to get the path in `ccb.py`
- document the new environment variable and Docker usage

## Testing
- `python -m py_compile ccb.py`

------
https://chatgpt.com/codex/tasks/task_e_6840db81cc7083218fbb45d904b21b3d