### PR TITLE
Add pytest tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Credit Card Benefits Tracker
+
+This project provides a Streamlit application to track and visualize credit card benefits.
+
+## Running Tests
+
+Install dependencies and run the test suite with `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit
 matplotlib
+pytest

--- a/tests/test_data_handling.py
+++ b/tests/test_data_handling.py
@@ -1,0 +1,71 @@
+import importlib.util
+import importlib.machinery
+import sys
+import types
+from datetime import datetime, timedelta
+from pathlib import Path
+
+class DummyModule(types.ModuleType):
+    def __getattr__(self, name):
+        def _(*args, **kwargs):
+            return None
+        return _
+
+def import_ccb():
+    sys.modules['streamlit'] = DummyModule('streamlit')
+    dummy_plot = DummyModule('matplotlib.pyplot')
+    matplotlib = types.ModuleType('matplotlib')
+    matplotlib.pyplot = dummy_plot
+    sys.modules['matplotlib'] = matplotlib
+    sys.modules['matplotlib.pyplot'] = dummy_plot
+
+    module_name = 'ccb'
+    file_path = Path(__file__).resolve().parents[1] / 'ccb.py'
+    loader = importlib.machinery.SourceFileLoader(module_name, str(file_path))
+    spec = importlib.util.spec_from_loader(module_name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    sys.modules[module_name] = module
+    return module
+
+
+def test_save_and_load(tmp_path):
+    ccb = import_ccb()
+    tmp_file = tmp_path / 'benefits.json'
+    ccb.DATA_FILE = str(tmp_file)
+
+    expected = {
+        'Benefit1': {
+            'description': 'desc',
+            'used': 0.5,
+            'reset_interval': 'Monthly',
+            'next_reset': '2099-01-01'
+        }
+    }
+    ccb.benefits = expected.copy()
+    ccb.save_benefits()
+
+    ccb.benefits = {}
+    loaded = ccb.load_benefits()
+    assert loaded == expected
+
+
+def test_check_resets(tmp_path):
+    ccb = import_ccb()
+    tmp_file = tmp_path / 'benefits.json'
+    ccb.DATA_FILE = str(tmp_file)
+    past = (datetime.now() - timedelta(days=1)).strftime('%Y-%m-%d')
+    ccb.benefits = {
+        'Benefit1': {
+            'description': 'desc',
+            'used': 1.0,
+            'reset_interval': 'Monthly',
+            'next_reset': past
+        }
+    }
+    ccb.save_benefits()
+    expected_next = ccb.calculate_reset_time('Monthly')
+    ccb.check_resets()
+    benefit = ccb.benefits['Benefit1']
+    assert benefit['used'] == 0.0
+    assert benefit['next_reset'] == expected_next


### PR DESCRIPTION
## Summary
- add a simple README
- include pytest dependency
- create tests for saving/loading data and reset logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840df9208988321918829c16996a46d