### PR TITLE
Add CSV export button

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ docker run -p 8501:8501 \
 ```
 
 If the variable is not set, the default file path will be used.
+
+## Exporting benefits
+
+A **Download CSV** button is available in the app. It converts the stored
+benefits dictionary to a table and lets you export the information as a CSV
+file for easy analysis.

--- a/ccb.py
+++ b/ccb.py
@@ -5,6 +5,7 @@ import streamlit as st
 import json
 import os
 import matplotlib.pyplot as plt
+import pandas as pd
 from datetime import datetime, timedelta
 
 # Default file to store the benefits data
@@ -122,6 +123,18 @@ def main():
     if benefits:
         cards = sorted({details.get("card", "") for details in benefits.values() if details.get("card")})
         selected_card = st.selectbox("Filter by Card", ["All"] + cards)
+
+        # Convert the benefits dictionary to a DataFrame for easier export
+        df = (
+            pd.DataFrame.from_dict(benefits, orient="index")
+            .reset_index()
+            .rename(columns={"index": "Benefit"})
+        )
+
+        csv = df.to_csv(index=False).encode("utf-8")
+        st.download_button(
+            "Download CSV", csv, "benefits.csv", mime="text/csv"
+        )
 
         for name, details in benefits.items():
             if selected_card != "All" and details.get("card") != selected_card:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit
 matplotlib
+pandas


### PR DESCRIPTION
## Summary
- convert benefits dict to Pandas DataFrame
- add download button to export CSV
- document export option
- include pandas dependency

## Testing
- `pip install --quiet -r requirements.txt`
- `python -m py_compile ccb.py`


------
https://chatgpt.com/codex/tasks/task_e_6840eb5da0008321a58473d40d009760